### PR TITLE
added functionality for agent to delete tweets

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -45,6 +45,7 @@ from hyperbolic_langchain.agent_toolkits import HyperbolicToolkit
 from hyperbolic_langchain.utils import HyperbolicAgentkitWrapper
 
 from twitter_langchain import (TwitterApiWrapper, TwitterToolkit)
+from custom_twitter_actions import create_delete_tweet_tool
 from hyperbolic_agentkit_core.actions.remote_shell import RemoteShellAction
 
 
@@ -163,6 +164,10 @@ def initialize_agent():
     twitter_toolkit = TwitterToolkit.from_twitter_api_wrapper(
         twitter_api_wrapper)
     tools.extend(twitter_toolkit.get_tools())
+
+    # Add our custom delete tweet tool
+    delete_tweet_tool = create_delete_tweet_tool(twitter_api_wrapper)
+    tools.append(delete_tweet_tool)
     
     deployMultiTokenTool = CdpTool(
         name="deploy_multi_token",

--- a/custom_twitter_actions.py
+++ b/custom_twitter_actions.py
@@ -1,0 +1,24 @@
+from collections.abc import Callable
+from json import dumps
+import tweepy
+from pydantic import BaseModel, Field
+from langchain.tools import Tool
+
+def delete_tweet(client: tweepy.Client, tweet_id: str) -> str:
+    """Delete a tweet from Twitter."""
+    try:
+        response = client.delete_tweet(id=tweet_id)
+        message = f"Successfully deleted tweet {tweet_id}:\n{dumps(response)}"
+    except tweepy.errors.TweepyException as e:
+        message = f"Error deleting tweet:\n{e}"
+    return message
+
+def create_delete_tweet_tool(twitter_api_wrapper) -> Tool:
+    """Create a delete tweet tool with the given Twitter API wrapper."""
+    return Tool(
+        name="delete_tweet",
+        description="""Delete a tweet using its ID. You can only delete tweets from your own account.
+        Input should be the tweet ID as a string.
+        Example: delete_tweet("1234567890")""",
+        func=lambda tweet_id: twitter_api_wrapper.run_action(delete_tweet, tweet_id=tweet_id)
+    )


### PR DESCRIPTION
### Task Description:
Enable the agent to delete a tweet given a tweet id, consuming the X api endpoint DELETE /2/tweets/:id. 
Note: we do not have to directly call this endpoint, as it is contained within the twitter_langchain package TwitterApiWrapper.

### Proposal:
Extend the functions within the CDP twitter toolkit by creating a new file called custom_twitter_actions.py to contain the delete_tweet function. This file will be used for all extensions of the CDP twitter toolkit in the future.

### Test Plan:
Prompt the agent to delete a specific tweet off of our account, providing the id.

<img width="625" alt="Screenshot 2024-12-27 at 17 37 50" src="https://github.com/user-attachments/assets/98a6a6a0-0930-4f8e-8db0-ecd8c2c6211b" />
