### PR TITLE
GitHub agent integration

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -55,6 +55,7 @@ from hyperbolic_langchain.agent_toolkits import HyperbolicToolkit
 from hyperbolic_langchain.utils import HyperbolicAgentkitWrapper
 from twitter_langchain import TwitterApiWrapper, TwitterToolkit
 from custom_twitter_actions import create_delete_tweet_tool, create_get_user_id_tool, create_get_user_tweets_tool, create_retweet_tool
+from custom_github_actions import GitHubAPIWrapper, create_evaluate_profiles_tool
 
 # Import local modules
 from utils import (
@@ -505,6 +506,19 @@ def process_character_config(character: Dict[str, Any]) -> str:
         - Retrieve tweets using user_tweets_tool
         - Reply to the most recent tweet of the selected KOL
 
+        6. GitHub Interaction:
+        -  Read GitHub profile URLs from CSV files
+        - Analyze candidates based on:
+          - Commit count (minimum 20)
+          - Follower count
+          - Primary programming language being Python
+        - When evaluating GitHub profiles:
+          - Review the evaluation summary to understand overall results
+          - Explain acceptance/rejection decisions based on the criteria
+          - Provide specific feedback about why candidates were rejected
+          - Make recommendations for borderline cases
+          - Consider the quality of contributions alongside quantity
+
         Important guidelines:
         1. Always stay in character
         2. Use your knowledge and capabilities appropriately
@@ -539,6 +553,8 @@ def process_character_config(character: Dict[str, Any]) -> str:
         5. Use retrieval_tool for Ethereum documentation
         6. Use get_user_id_tool to find KOL user IDs
         7. Use user_tweets_tool to retrieve KOL tweets
+        8. Use evaluate_github_profiles_tool for reviewing GitHub candidates
+           
 
         Before responding to any input, analyze the situation and plan your response in <response_planning> tags:
         1. Determine if the input is a mention or a regular message
@@ -867,6 +883,11 @@ async def initialize_agent():
         # Request Tools
         if os.getenv("USE_REQUEST_TOOLS", "false").lower() == "true":
             tools.extend(toolkit.get_tools())
+
+        # Add GitHub profile evaluation tool
+        if os.getenv("USE_GITHUB_TOOLS", "false").lower() == "true":
+            github_wrapper = GitHubAPIWrapper(os.getenv("GITHUB_TOKEN"))
+            tools.append(create_evaluate_profiles_tool(github_wrapper))
 
 
 

--- a/github_agent/custom_github_actions.py
+++ b/github_agent/custom_github_actions.py
@@ -1,0 +1,161 @@
+from collections.abc import Callable
+from json import dumps
+import pandas as pd
+from github import Github, GithubException
+from langchain.tools import Tool
+from typing import List
+import re
+
+class GitHubAPIWrapper:
+    def __init__(self, github_token: str):
+        self.client = Github(github_token)
+        
+    def run_action(self, action: Callable, **kwargs):
+        return action(self.client, **kwargs)
+
+def extract_username_from_url(url: str) -> str:
+    """Extract GitHub username from profile URL."""
+    # Handle different GitHub URL formats
+    patterns = [
+        r"github\.com/([^/]+)/?$",  # https://github.com/username
+        r"github\.com/([^/]+)/?(?:\?|#|$)",  # https://github.com/username?tab=repositories
+        #some of the urls are not github links, and do not work when clicked (invalid links)
+        #some of the urls are personal websites, which are not valid github profiles
+    ]
+    
+    for pattern in patterns:
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    
+    raise ValueError(f"Could not extract username from URL: {url}")
+
+def evaluate_github_profiles_from_csv(client: Github, csv_path: str, 
+                                    url_column: str = "github_url",
+                                    min_commits: int = 20, 
+                                    min_followers: int = 0) -> str:
+    """Evaluate GitHub profiles from URLs in a CSV file."""
+    try:
+        # Read CSV file
+        df = pd.read_csv(csv_path)
+        
+        if url_column not in df.columns:
+            return f"Error: Column '{url_column}' not found in CSV file. Available columns: {', '.join(df.columns)}"
+        
+        results = []
+        accepted_candidates = []
+        rejected_candidates = []
+        
+        # Process each URL
+        for url in df[url_column]:
+            try:
+                # Extract username from URL
+                username = extract_username_from_url(url)
+                
+                # Get user profile
+                user = client.get_user(username)
+                
+                # Get contribution stats
+                contributions = 0
+                for repo in user.get_repos():
+                    try:
+                        stats = repo.get_stats_contributors()
+                        if stats:
+                            for stat in stats:
+                                if stat.author.login == username:
+                                    contributions += sum(week.total for week in stat.weeks)
+                    except GithubException:
+                        continue
+
+                # Get language stats
+                language_stats = {}
+                for repo in user.get_repos():
+                    if repo.language:
+                        language_stats[repo.language] = language_stats.get(repo.language, 0) + 1
+                
+                primary_language = max(language_stats.items(), key=lambda x: x[1])[0] if language_stats else "None"
+                
+                # Enhanced evaluation with clear accept/reject decision
+                meets_requirements = (
+                    contributions >= min_commits and 
+                    user.followers >= min_followers and
+                    primary_language == "Python"
+                )
+                
+                evaluation = {
+                    "github_url": url,
+                    "username": username,
+                    "name": user.name,
+                    "total_commits": contributions,
+                    "followers": user.followers,
+                    "primary_language": primary_language,
+                    "criteria_evaluation": {
+                        "commits": f"{contributions}/{min_commits} required commits",
+                        "followers": f"{user.followers}/{min_followers} required followers",
+                        "language_expertise": f"Primary language: {primary_language}"
+                    },
+                    "decision": "ACCEPTED" if meets_requirements else "REJECTED",
+                    "reason": (
+                        "Meets all criteria" if meets_requirements else
+                        f"Does not meet requirements: " + 
+                        ", ".join([
+                            f"insufficient commits ({contributions}/{min_commits})" if contributions < min_commits else "",
+                            f"insufficient followers ({user.followers}/{min_followers})" if user.followers < min_followers else ""
+                        ]).strip(", ")
+                    )
+                }
+                
+                results.append(evaluation)
+                if meets_requirements:
+                    accepted_candidates.append(username)
+                else:
+                    rejected_candidates.append(username)
+                
+            except Exception as e:
+                results.append({
+                    "github_url": url,
+                    "error": str(e),
+                    "decision": "REJECTED",
+                    "reason": f"Error processing profile: {str(e)}"
+                })
+                rejected_candidates.append(url)
+        
+        summary = f"""
+GitHub Profile Evaluation Summary:
+--------------------------------
+Total Candidates: {len(results)}
+Accepted: {len(accepted_candidates)} ({', '.join(accepted_candidates) if accepted_candidates else 'None'})
+Rejected: {len(rejected_candidates)} ({', '.join(rejected_candidates) if rejected_candidates else 'None'})
+
+Detailed Evaluations:
+{dumps(results, indent=2)}
+"""
+        return summary
+    
+    except Exception as e:
+        return f"Error processing CSV file: {str(e)}"
+
+def create_evaluate_profiles_tool(github_api_wrapper) -> Tool:
+    """Create a tool to evaluate GitHub profiles from a CSV file."""
+    return Tool(
+        name="evaluate_github_profiles",
+        description="""Evaluate GitHub profiles from URLs in a CSV file.
+        Input should be the path to a CSV file containing GitHub profile URLs.
+        The CSV should have a column named 'Github URL' with the profile URLs.
+        Example: evaluate_github_profiles("candidates.csv")
+        Returns evaluation based on:
+        - Minimum 20 commits
+        - Minimum 0 followers
+        - Programming language expertise (Python)""",
+        func=lambda csv_path: github_api_wrapper.run_action(
+            evaluate_github_profiles_from_csv,
+            csv_path=csv_path,
+            min_commits=20,
+            min_followers=0
+        )
+    )
+
+
+
+#the tools created in this file are:
+# create_evaluate_profiles_tool, which is used to evaluate multiple GitHub users as valid event candidates.

--- a/github_agent/custom_github_actions.py
+++ b/github_agent/custom_github_actions.py
@@ -3,24 +3,108 @@ from json import dumps
 import pandas as pd
 from github import Github, GithubException
 from langchain.tools import Tool
-from typing import List
+from typing import List, Dict, Optional
 import re
+import time
+import requests
 
 class GitHubAPIWrapper:
     def __init__(self, github_token: str):
-        self.client = Github(github_token)
+        self.token = github_token
+        self.headers = {
+            'Authorization': f'Bearer {github_token}',
+            'Content-Type': 'application/json',
+        }
+        self.endpoint = 'https://api.github.com/graphql'
+
+    def execute_query(self, query: str, variables: Dict) -> Dict:
+        """Execute a GraphQL query against GitHub's API."""
+        response = requests.post(
+            self.endpoint,
+            json={'query': query, 'variables': variables},
+            headers=self.headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_user_profile_data(self, username: str) -> Optional[Dict]:
+        """Get user's contributions and top languages."""
+        query = """
+        query($userName:String!) {
+            user(login: $userName) {
+                contributionsCollection {
+                    contributionCalendar {
+                        totalContributions
+                    }
+                }
+                repositories(first: 10, orderBy: {field: STARGAZERS, direction: DESC}, ownerAffiliations: [OWNER]) {
+                    nodes {
+                        languages(first: 5, orderBy: {field: SIZE, direction: DESC}) {
+                            edges {
+                                size
+                                node {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        """
+        try:
+            result = self.execute_query(query, {'userName': username})
+            
+            # Get contributions
+            contributions = result['data']['user']['contributionsCollection']['contributionCalendar']['totalContributions']
+            
+            # Calculate language statistics
+            language_stats = {}
+            repositories = result['data']['user']['repositories']['nodes']
+            
+            for repo in repositories:
+                if repo['languages'] and repo['languages']['edges']:
+                    for lang_edge in repo['languages']['edges']:
+                        lang_name = lang_edge['node']['name']
+                        lang_size = lang_edge['size']
+                        language_stats[lang_name] = language_stats.get(lang_name, 0) + lang_size
+            
+            # Sort languages by total size
+            sorted_languages = sorted(language_stats.items(), key=lambda x: x[1], reverse=True)
+            top_languages = [lang[0] for lang in sorted_languages[:3]]  # Reduced from 5 to 3 top languages
+            
+            return {
+                'contributions': contributions,
+                'top_languages': top_languages,
+                'primary_language': top_languages[0] if top_languages else None
+            }
+            
+        except Exception as e:
+            print(f"Error fetching data for {username}: {e}")
+            return None
+
+def verify_github_auth(client: Github) -> bool:
+    """Verify GitHub authentication and permissions."""
+    try:
+        # Get authenticated user
+        user = client.get_user()
+        print(f"Authenticated as: {user.login}")
         
-    def run_action(self, action: Callable, **kwargs):
-        return action(self.client, **kwargs)
+        # Check rate limit
+        rate_limit = client.get_rate_limit()
+        print(f"API Rate Limit: {rate_limit.core.remaining}/{rate_limit.core.limit}")
+        
+        return True
+    except GithubException as e:
+        print(f"Authentication Error: {e}")
+        return False
+
 
 def extract_username_from_url(url: str) -> str:
     """Extract GitHub username from profile URL."""
-    # Handle different GitHub URL formats
     patterns = [
-        r"github\.com/([^/]+)/?$",  # https://github.com/username
-        r"github\.com/([^/]+)/?(?:\?|#|$)",  # https://github.com/username?tab=repositories
-        #some of the urls are not github links, and do not work when clicked (invalid links)
-        #some of the urls are personal websites, which are not valid github profiles
+        r"github\.com/([^/]+)/?$",
+        r"github\.com/([^/]+)/?(?:\?|#|$)",
     ]
     
     for pattern in patterns:
@@ -30,14 +114,22 @@ def extract_username_from_url(url: str) -> str:
     
     raise ValueError(f"Could not extract username from URL: {url}")
 
-def evaluate_github_profiles_from_csv(client: Github, csv_path: str, 
-                                    url_column: str = "github_url",
-                                    min_commits: int = 20, 
+def evaluate_github_profiles_from_csv(github_api: GitHubAPIWrapper, 
+                                    csv_path: str = "github_agent/csvs/PMF or Die_ AI Agent Hackathon @ Hyper(r)House - Guests - 2025-01-30-09-24-49.csv",
+                                    url_column: str = "Github URL",
+                                    min_commits: int = 20,
                                     min_followers: int = 0) -> str:
     """Evaluate GitHub profiles from URLs in a CSV file."""
+    print("=== Starting GitHub Profile Evaluation ===")
+    print(f"Parameters received:")
+    print(f"- csv_path: {csv_path}")
+    print(f"- url_column: {url_column}")
+    print(f"- min_commits: {min_commits}")
+    
     try:
         # Read CSV file
         df = pd.read_csv(csv_path)
+        print(f"Found {len(df)} entries")
         
         if url_column not in df.columns:
             return f"Error: Column '{url_column}' not found in CSV file. Available columns: {', '.join(df.columns)}"
@@ -47,61 +139,51 @@ def evaluate_github_profiles_from_csv(client: Github, csv_path: str,
         rejected_candidates = []
         
         # Process each URL
-        for url in df[url_column]:
+        for idx, url in enumerate(df[url_column]):
+            print(f"Processing URL {idx + 1}/{len(df)}: {url}")
             try:
-                # Extract username from URL
-                username = extract_username_from_url(url)
-                
-                # Get user profile
-                user = client.get_user(username)
-                
-                # Get contribution stats
-                contributions = 0
-                for repo in user.get_repos():
-                    try:
-                        stats = repo.get_stats_contributors()
-                        if stats:
-                            for stat in stats:
-                                if stat.author.login == username:
-                                    contributions += sum(week.total for week in stat.weeks)
-                    except GithubException:
-                        continue
+                if not isinstance(url, str) or not url.startswith('https://github.com/'):
+                    results.append({
+                        "github_url": url,
+                        "error": "Invalid GitHub URL format",
+                        "decision": "REJECTED",
+                        "reason": "Invalid GitHub URL format"
+                    })
+                    rejected_candidates.append(str(url))
+                    continue
 
-                # Get language stats
-                language_stats = {}
-                for repo in user.get_repos():
-                    if repo.language:
-                        language_stats[repo.language] = language_stats.get(repo.language, 0) + 1
+                username = extract_username_from_url(url)
+                print(f"Extracted username: {username}")
                 
-                primary_language = max(language_stats.items(), key=lambda x: x[1])[0] if language_stats else "None"
+                # Get user data using GraphQL
+                user_data = github_api.get_user_profile_data(username)
+                if user_data is None:
+                    raise ValueError("Could not fetch user data")
                 
-                # Enhanced evaluation with clear accept/reject decision
-                meets_requirements = (
-                    contributions >= min_commits and 
-                    user.followers >= min_followers and
-                    primary_language == "Python"
-                )
+                contributions = user_data['contributions']
+                top_languages = user_data['top_languages']
+                primary_language = user_data['primary_language']
+                
+                print(f"Found {contributions} contributions for {username}")
+                print(f"Top languages: {', '.join(top_languages)}")
+                
+                # Make decision based on contribution count
+                meets_requirements = contributions >= min_commits
                 
                 evaluation = {
                     "github_url": url,
                     "username": username,
-                    "name": user.name,
-                    "total_commits": contributions,
-                    "followers": user.followers,
+                    "total_contributions": contributions,
+                    "top_languages": top_languages,
                     "primary_language": primary_language,
                     "criteria_evaluation": {
-                        "commits": f"{contributions}/{min_commits} required commits",
-                        "followers": f"{user.followers}/{min_followers} required followers",
-                        "language_expertise": f"Primary language: {primary_language}"
+                        "contributions": f"{contributions}/{min_commits} required contributions",
+                        "languages": f"Primary language: {primary_language}, Top languages: {', '.join(top_languages)}"
                     },
                     "decision": "ACCEPTED" if meets_requirements else "REJECTED",
                     "reason": (
                         "Meets all criteria" if meets_requirements else
-                        f"Does not meet requirements: " + 
-                        ", ".join([
-                            f"insufficient commits ({contributions}/{min_commits})" if contributions < min_commits else "",
-                            f"insufficient followers ({user.followers}/{min_followers})" if user.followers < min_followers else ""
-                        ]).strip(", ")
+                        f"Insufficient contributions ({contributions}/{min_commits})"
                     )
                 }
                 
@@ -112,6 +194,7 @@ def evaluate_github_profiles_from_csv(client: Github, csv_path: str,
                     rejected_candidates.append(username)
                 
             except Exception as e:
+                print(f"Error processing {url}: {e}")
                 results.append({
                     "github_url": url,
                     "error": str(e),
@@ -119,7 +202,7 @@ def evaluate_github_profiles_from_csv(client: Github, csv_path: str,
                     "reason": f"Error processing profile: {str(e)}"
                 })
                 rejected_candidates.append(url)
-        
+
         summary = f"""
 GitHub Profile Evaluation Summary:
 --------------------------------
@@ -128,7 +211,7 @@ Accepted: {len(accepted_candidates)} ({', '.join(accepted_candidates) if accepte
 Rejected: {len(rejected_candidates)} ({', '.join(rejected_candidates) if rejected_candidates else 'None'})
 
 Detailed Evaluations:
-{dumps(results, indent=2)}
+{results}
 """
         return summary
     
@@ -140,16 +223,12 @@ def create_evaluate_profiles_tool(github_api_wrapper) -> Tool:
     return Tool(
         name="evaluate_github_profiles",
         description="""Evaluate GitHub profiles from URLs in a CSV file.
-        Input should be the path to a CSV file containing GitHub profile URLs.
-        The CSV should have a column named 'Github URL' with the profile URLs.
-        Example: evaluate_github_profiles("candidates.csv")
-        Returns evaluation based on:
-        - Minimum 20 commits
-        - Minimum 0 followers
-        - Programming language expertise (Python)""",
-        func=lambda csv_path: github_api_wrapper.run_action(
-            evaluate_github_profiles_from_csv,
-            csv_path=csv_path,
+        This tool automatically reads from a hardcoded CSV file.
+        No input parameters needed - just call the tool directly.""",
+        func=lambda *args: evaluate_github_profiles_from_csv(
+            github_api=github_api_wrapper,
+            csv_path="github_agent/csvs/PMF or Die_ AI Agent Hackathon @ Hyper(r)House - Guests - 2025-01-30-09-24-49.csv",
+            url_column="Github URL",
             min_commits=20,
             min_followers=0
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ google-cloud-aiplatform = "^1.38.0"
 vertexai = "^0.0.1"
 numpy = "<2.0.0"
 gradio = "^5.12.0"
+pygithub = "^2.5.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- Using GraphQL Github API instead of REST API
- Smoother for getting total contribution count and most used languages across most starred repo's where they are owners
- Agent decides which to accept/reject based on prioritizing higher contribution counts and python in top languages (specified in character_config)
- Tested with csv file of PMF or Die Agent Hackathon applicant list (accepted 11, rejected 19) 